### PR TITLE
Fix center constraints for chaining methods

### DIFF
--- a/StraitJacket/Models/Alignment.swift
+++ b/StraitJacket/Models/Alignment.swift
@@ -137,7 +137,7 @@ public enum Alignment: Hashable {
 
     internal var isHorizontalAlignment: Bool {
         switch self {
-        case .leading, .softLeading, .trailing, .softTrailing, .left, .softLeft, .right, .softRight:
+        case .leading, .softLeading, .trailing, .softTrailing, .left, .softLeft, .right, .softRight, .centerX:
             return true
         case .alignmentWithInset(let alignment, _):
             return alignment.isHorizontalAlignment
@@ -154,7 +154,7 @@ public enum Alignment: Hashable {
 
     internal var isVerticalAlignment: Bool {
         switch self {
-        case .top, .softTop, .bottom, .softBottom:
+        case .top, .softTop, .bottom, .softBottom, .centerY:
             return true
         case .alignmentWithInset(let alignment, _):
             return alignment.isVerticalAlignment

--- a/StraitJacketTests/GuidedRestraintTests.swift
+++ b/StraitJacketTests/GuidedRestraintTests.swift
@@ -197,6 +197,22 @@ class GuidedRestraintTests: XCTestCase {
         XCTAssert(allAlignmentAttributes == expectedAlignmentAttributes)
     }
 
+    func testHorizontalChainInGuideCentersY() {
+        let label1 = UILabel(), label2 = UILabel()
+        let view = UIView()
+
+        let viewRestraint = Restraint(view, items: [label1, label2])
+            .chainHorizontally([label1, label2], in: view, aligning: [.centerY])
+        viewRestraint.activate()
+        let constraints = view.constraints.filter { $0.firstAttribute == $0.secondAttribute && $0.firstAttribute == .centerY }
+
+        let views = constraints.compactMap { $0.firstItem as? UIView }
+        let viewSet = Set(views)
+
+        XCTAssert(viewSet.contains(label1))
+        XCTAssert(viewSet.contains(label2))
+    }
+
     func testChainVerticallyInGuide() {
         let view = UIView()
         let subview1 = UIView(), subview2 = UIView()
@@ -219,6 +235,22 @@ class GuidedRestraintTests: XCTestCase {
         let actualSubview2AttributeSet = Set(subview2Attributes)
         let expectedSubview2AttributeSet = Set([NSLayoutConstraint.Attribute.leading, .bottom, .trailing].map { String(describing: $0) })
         XCTAssert(expectedSubview2AttributeSet == actualSubview2AttributeSet)
+    }
+
+    func testVerticalChainInGuideCentersX() {
+        let label1 = UILabel(), label2 = UILabel()
+        let view = UIView()
+
+        let viewRestraint = Restraint(view, items: [label1, label2])
+            .chainVertically([label1, label2], in: view, aligning: [.centerX])
+        viewRestraint.activate()
+        let constraints = view.constraints.filter { $0.firstAttribute == $0.secondAttribute && $0.firstAttribute == .centerX }
+
+        let views = constraints.compactMap { $0.firstItem as? UIView }
+        let viewSet = Set(views)
+
+        XCTAssert(viewSet.contains(label1))
+        XCTAssert(viewSet.contains(label2))
     }
 
     func testVerticalChainInGuideCanInset() {


### PR DESCRIPTION
Center anchors are not being set when using the chain methods